### PR TITLE
komorebi: ignore PalworldSaveTools, PSP exes and Bitwarden window

### DIFF
--- a/dot_config/komorebi/komorebi.json
+++ b/dot_config/komorebi/komorebi.json
@@ -117,6 +117,21 @@
       "kind": "Class",
       "id": "Tauri Window",
       "matching_strategy": "Contains"
+    },
+    {
+      "kind": "Exe",
+      "id": "PalworldSaveTools.exe",
+      "matching_strategy": "Equals"
+    },
+    {
+      "kind": "Exe",
+      "id": "PSP.exe",
+      "matching_strategy": "Equals"
+    },
+    {
+      "kind": "Title",
+      "id": "Bitwarden",
+      "matching_strategy": "StartsWith"
     }
   ]
 }


### PR DESCRIPTION
Adds three `ignore_rules` to `dot_config/komorebi/komorebi.json`:

- **Exe** `PalworldSaveTools.exe` (Equals)
- **Exe** `PSP.exe` (Equals)
- **Title** `Bitwarden` (StartsWith)

Note: Bitwarden was already in `floating_applications`; now also ignored (removed from tiling entirely rather than just floated). Exe names assumed to be `PalworldSaveTools.exe` / `PSP.exe` — adjust if the actual process names differ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)